### PR TITLE
Fixed to call enqueue scripts in the  hook.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2018-02-01
+
+### Fixed
+- Fixed to call enqueue scripts in the `admin_enqueue_scripts` hook. Caused previously an exception.
+- Added a cleaner way to get plugin version.
+
 ## [1.0.2] - 2018-01-25
 
 ### Fixed

--- a/plugin.php
+++ b/plugin.php
@@ -14,13 +14,34 @@
 class RequiredTabs {
 
     /**
+     * Holds the plugin version.
+     *
+     * @var string
+     */
+    protected $version = '';
+
+    /**
+     * Holds plugin scripts dependencies.
+     *
+     * @var array
+     */
+    protected $dependencies = [];
+
+    /**
      * Initalize the plugin and enqueue the script
      *
      * @return  void
      */
     public function __construct() {
 
-        add_action( 'admin_enqueue_scripts', [ __CLASS__, 'required_tabs_scripts_and_styles' ] );
+        // Get plugin data for scripts and styles versions.
+        $plugin_data = get_plugin_data( __FILE__ );
+        $this->version = $plugin_data['Version'];
+
+        // Filter dependencies in case you for example provide jQuery separately from the WordPress system
+        $this->dependencies = apply_filters( 'acf/required_tabs/dependencies', [ 'jquery' ] );
+
+        add_action( 'admin_enqueue_scripts', [ $this, 'required_tabs_scripts_and_styles' ] );
     }
 
     /**
@@ -28,17 +49,9 @@ class RequiredTabs {
      *
      * @return void
      */
-    public static function required_tabs_scripts_and_styles() {
-
-        // Get plugin data for scripts and styles versions.
-        $plugin_data = get_plugin_data( __FILE__ );
-        $version     = $plugin_data['Version'];
-
-        // Filter dependencies in case you for example provide jQuery separately from the WordPress system
-        $dependencies = apply_filters( 'acf/required_tabs/dependencies', [ 'jquery' ] );
-
-        wp_enqueue_style( 'acf_required_tabs', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'assets/dist/main.css', [], $version, 'all' );
-        wp_enqueue_script( 'acf_required_tabs', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'assets/dist/main.js', $dependencies, $version, false );
+    public function required_tabs_scripts_and_styles() {
+        wp_enqueue_style( 'acf_required_tabs', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'assets/dist/main.css', [], $this->version, 'all' );
+        wp_enqueue_script( 'acf_required_tabs', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'assets/dist/main.js', $this->dependencies, $this->version, false );
     }
 }
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,9 +3,13 @@
  * Plugin Name: ACF Required Tabs
  * Plugin URI: https://github.com/devgeniem/acf-required-tabs
  * Description: An Advanced Custom Fields plugin that adds an indicator for tabs that contain unfilled required fields.
- * Version: 1.0.2
+ * Version: 1.0.3
  * Author: Geniem Oy / Miika Arponen
  * Author URI: http://www.geniem.com
+ */
+
+/**
+ * Class RequiredTabs
  */
 class RequiredTabs {
 
@@ -15,19 +19,26 @@ class RequiredTabs {
      * @return  void
      */
     public function __construct() {
-        // Only on the admin side
-        if ( is_admin() ) {
-            $plugin_data = get_file_data( __FILE__, [ 'Version' => 'Version' ], 'plugin' );
 
-            $version = $plugin_data['Version'];
+        add_action( 'admin_enqueue_scripts', [ __CLASS__, 'required_tabs_scripts_and_styles' ] );
+    }
 
-            // Filter dependencies in case you for example provide jQuery separately from the WordPress system
-            $dependencies = apply_filters( 'acf/required_tabs/dependencies', [ 'jquery' ] );
+    /**
+     * Required tabs scripts and styles.
+     *
+     * @return void
+     */
+    public static function required_tabs_scripts_and_styles() {
 
-            wp_enqueue_script( 'acf_required_tabs', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'assets/dist/main.js', $dependencies, $version, false );
+        // Get plugin data for scripts and styles versions.
+        $plugin_data = get_plugin_data( __FILE__ );
+        $version     = $plugin_data['Version'];
 
-            wp_enqueue_style( 'acf_required_tabs', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'assets/dist/main.css', [], $version, 'all' );
-        }
+        // Filter dependencies in case you for example provide jQuery separately from the WordPress system
+        $dependencies = apply_filters( 'acf/required_tabs/dependencies', [ 'jquery' ] );
+
+        wp_enqueue_style( 'acf_required_tabs', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'assets/dist/main.css', [], $version, 'all' );
+        wp_enqueue_script( 'acf_required_tabs', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'assets/dist/main.js', $dependencies, $version, false );
     }
 }
 


### PR DESCRIPTION
### Fixed
- Fixed to call enqueue scripts in the `admin_enqueue_scripts` hook. Caused previously an exception.
- Added a cleaner way to get plugin version.