### PR TITLE
Fix the missing function error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2018-04-227
+
+### Fixed
+
+- The plugin is now initalized in the `admin_init` hook to fix the missing `get_plugin_data` function error.
+
 ## [1.0.5] - 2018-04-26
 
 ### Fixed

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: ACF Required Tabs
  * Plugin URI: https://github.com/devgeniem/acf-required-tabs
  * Description: An Advanced Custom Fields plugin that adds an indicator for tabs that contain unfilled required fields.
- * Version: 1.0.5
+ * Version: 1.0.6
  * Author: Geniem Oy / Miika Arponen
  * Author URI: http://www.geniem.com
  */
@@ -28,26 +28,27 @@ class RequiredTabs {
     protected $dependencies = [];
 
     /**
-     * Initalize the plugin and enqueue the script
-     *
-     * @return  void
+     * Construct the plugin by adding hooks.
      */
     public function __construct() {
-
-        // Get plugin data for scripts and styles versions.
-        $plugin_data = get_plugin_data( __FILE__ );
-        $this->version = $plugin_data['Version'];
-
-        // Filter dependencies in case you for example provide jQuery separately from the WordPress system
-        $this->dependencies = apply_filters( 'acf/required_tabs/dependencies', [ 'jquery' ] );
-
+        add_action( 'admin_init', [ $this, 'init_plugin' ] );
         add_action( 'admin_enqueue_scripts', [ $this, 'required_tabs_scripts_and_styles' ] );
     }
 
     /**
+     * Initializes the plugin data on 'admin_init' hook.
+     */
+    public function init_plugin() {
+        // Get plugin data for scripts and styles versions.
+        $plugin_data   = get_plugin_data( __FILE__ );
+        $this->version = $plugin_data['Version'];
+
+        // Filter dependencies in case you for example provide jQuery separately from the WordPress system
+        $this->dependencies = apply_filters( 'acf/required_tabs/dependencies', [ 'jquery' ] );
+    }
+
+    /**
      * Required tabs scripts and styles.
-     *
-     * @return void
      */
     public function required_tabs_scripts_and_styles() {
         wp_enqueue_style( 'acf_required_tabs', trailingslashit( plugin_dir_url( __FILE__ ) ) . 'assets/dist/main.css', [], $this->version, 'all' );


### PR DESCRIPTION
The `get_plugin_data` function call threw an error on some admin pages. Changed the plugin initialization to fix this error.